### PR TITLE
Fix README duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ ssh pi@<your-pi-ip>
 ```
 
 ### 3. Install Git
-Install Git 
 
 ```bash
 sudo apt update && sudo apt install -y git


### PR DESCRIPTION
## Summary
- remove duplicate 'Install Git' line from README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a17f438e483208823fc4298098aa2