### PR TITLE
Fix CUPS remote access

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ sudo apt update && sudo apt install -y git
 curl -sSL https://raw.githubusercontent.com/creol/PiPrintQ/main/install.sh | bash
 ```
 
+The installer also opens the CUPS web interface to your local network so you can
+manage printers from any machine. Visit `http://piprintq:631` after installation
+to add or configure printers.
+
 ---
 
 ## 📂 Folder Structure

--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,9 @@ fi
 sudo sed -i '/<Location \/>/,/<\/Location>/ { /Allow @local/d; /<\/Location>/i\  Allow @local }' /etc/cups/cupsd.conf
 sudo sed -i '/<Location \/admin>/,/<\/Location>/ { /Allow @local/d; /<\/Location>/i\  Allow @local }' /etc/cups/cupsd.conf
 
+# Ensure remote access stays enabled
+sudo cupsctl --remote-any --share-printers
+
 # Restart CUPS to apply configuration changes
 sudo systemctl restart cups
 


### PR DESCRIPTION
## Summary
- ensure CUPS remote access stays enabled by running `cupsctl`
- document that the installer opens the CUPS web interface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685a22e7328c832088c937f29a486dec