### PR TITLE
Configure PrintQueue share with authentication

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,6 +79,12 @@ for i in {1..10}; do
 done
 
 # Configure Samba to share PrintQueue
+# Ensure the Samba user "pi" exists with password "print"
+if ! sudo pdbedit -L | grep -q '^pi:'; then
+  echo -e "print\nprint" | sudo smbpasswd -s -a pi
+fi
+
+# Configure Samba to share PrintQueue requiring authentication
 if ! grep -q "\[PrintQueue\]" /etc/samba/smb.conf; then
   sudo tee -a /etc/samba/smb.conf > /dev/null <<EOF
 
@@ -86,10 +92,11 @@ if ! grep -q "\[PrintQueue\]" /etc/samba/smb.conf; then
    path = /home/pi/PrintQueue
    browseable = yes
    writable = yes
-   guest ok = yes
+   guest ok = no
+   valid users = pi
    create mask = 0777
    directory mask = 0777
-   public = yes
+   public = no
 EOF
 fi
 


### PR DESCRIPTION
## Summary
- configure Samba share to disable guest access
- ensure Samba user `pi` exists with password `print`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685a2bf3152083208eaff2577f98ad70