### PR TITLE
Run installer when choosing update

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,21 +104,17 @@ Use this interface to:
    
 ---
 
-## 🔁 Updating from GitHub
+## 🔁 Reinstalling/Updating
 
 From the boot menu, choose:
 
 ```
-9. Update PiPrintQ from GitHub
+9. Run installer from GitHub
 ```
 
-This option:
-* **Discards local changes**
-* **Pulls the latest version**
-* **Reinstalls dependencies**
-* **Restarts services**
+This downloads and runs the latest `install.sh` script, giving you a clean installation of PiPrintQ. When it finishes you'll be prompted to reboot.
 
-> 🔒 This system is configured to only **pull from GitHub**, preventing any accidental overwrites or pushes from the Pi.
+> 🔒 The installer always pulls the latest code from GitHub, discarding any local changes.
 
 ---
 

--- a/bootmenu.sh
+++ b/bootmenu.sh
@@ -11,7 +11,7 @@ while true; do
   echo "6. Launch web dashboard"
   echo "7. Reset Print Counts"
   echo "8. Clear Archive Files"
-  echo "9. Update from GitHub"
+  echo "9. Run installer from GitHub"
   echo "10. Reboot System"
   echo "11. Exit"
   echo "============================="
@@ -27,18 +27,8 @@ while true; do
     7) cat /home/pi/web_dashboard/stats.clear > /home/pi/web_dashboard/stats.json ;;
     8) rm -f /home/pi/PrintCompleted/* && echo "Archive cleared." ;;
     9)
-  echo "Updating from GitHub..."
-  cd /home/pi/web_dashboard || exit
-  git fetch origin
-  git reset --hard origin/main
-  git clean -fd
-  echo "Installing venv dependencies..."
-  /home/pi/web_dashboard/venv/bin/pip install -r requirements.txt
-  echo "Restarting services..."
-  sudo systemctl restart piprintq.service
-  sudo systemctl restart web-dashboard.service
-  echo "Update complete. Restarting boot menu..."
-  exec /home/pi/web_dashboard/bootmenu.sh
+  echo "Running latest installer..."
+  curl -sSL https://raw.githubusercontent.com/creol/PiPrintQ/main/install.sh | bash
   ;;
     10) sudo reboot ;;
     11) exit ;;


### PR DESCRIPTION
## Summary
- rework bootmenu option 9 to run install script
- adjust menu wording for option 9
- document new update method in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685b13e71ae88320b3af254729e7c279