### PR TITLE
Display network links in bootmenu

### DIFF
--- a/bootmenu.sh
+++ b/bootmenu.sh
@@ -2,6 +2,9 @@
 
 while true; do
   clear
+  IP=$(hostname -I | awk '{print $1}')
+  echo "Dashboard: http://$IP:5000"
+  echo "CUPS Admin: http://$IP:631/printers"
   echo "==== Pi Print Queue Menu ===="
   echo "1. Start print watcher"
   echo "2. Stop print watcher"


### PR DESCRIPTION
## Summary
- add hostname URLs for dashboard and CUPS to bootmenu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6861adf8194c8320a059436d6d8161aa