### PR TITLE
Update gitignore for common Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vscode/settings.json
+__pycache__/
+*.pyc
+*.log


### PR DESCRIPTION
## Summary
- ignore Python build artifacts and logs in `.gitignore`

## Testing
- `pytest -q` *(fails: FileNotFoundError due to missing round_robin.json)*

------
https://chatgpt.com/codex/tasks/task_e_686210c1d7d48320a0b782875464eb8e